### PR TITLE
feat(database): extend ChromaDB metadata schema for structural metrics

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Build and utility scripts."""

--- a/scripts/migrate_chromadb_metrics.py
+++ b/scripts/migrate_chromadb_metrics.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Migration script to add structural code metrics to existing ChromaDB chunks.
+
+This script:
+1. Connects to existing ChromaDB collection
+2. For each chunk lacking metrics fields, adds default values
+3. Logs progress and is idempotent (safe to run multiple times)
+
+Usage:
+    python scripts/migrate_chromadb_metrics.py
+    python scripts/migrate_chromadb_metrics.py --persist-dir /path/to/chromadb
+    python scripts/migrate_chromadb_metrics.py --dry-run  # Preview changes only
+
+Default ChromaDB location: .mcp-vector-search/chromadb
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+try:
+    import chromadb
+except ImportError:
+    logger.error("ChromaDB not installed. Run: uv pip install chromadb")
+    sys.exit(1)
+
+
+# Default metrics for chunks without structural analysis
+DEFAULT_METRICS: dict[str, Any] = {
+    "cognitive_complexity": 0,
+    "cyclomatic_complexity": 1,  # Base complexity
+    "max_nesting_depth": 0,
+    "parameter_count": 0,
+    "lines_of_code": 0,
+    "complexity_grade": "A",
+    "code_smells": "[]",  # JSON string (ChromaDB doesn't support lists in metadata)
+    "smell_count": 0,
+}
+
+
+def get_default_persist_dir() -> Path:
+    """Get default ChromaDB persist directory."""
+    return Path.cwd() / ".mcp-vector-search" / "chromadb"
+
+
+async def migrate_metrics(
+    persist_dir: Path,
+    collection_name: str = "code_search",
+    dry_run: bool = False,
+    batch_size: int = 100,
+) -> dict[str, int]:
+    """Migrate existing chunks to include structural metrics.
+
+    Args:
+        persist_dir: ChromaDB persist directory
+        collection_name: Name of the collection to migrate
+        dry_run: If True, preview changes without applying
+        batch_size: Number of chunks to process per batch
+
+    Returns:
+        Dictionary with migration statistics
+    """
+    if not persist_dir.exists():
+        logger.error(f"ChromaDB directory not found: {persist_dir}")
+        return {"total": 0, "migrated": 0, "skipped": 0, "errors": 0}
+
+    logger.info(f"{'[DRY RUN] ' if dry_run else ''}Starting migration...")
+    logger.info(f"ChromaDB location: {persist_dir}")
+    logger.info(f"Collection name: {collection_name}")
+
+    # Connect to ChromaDB
+    try:
+        client = chromadb.PersistentClient(
+            path=str(persist_dir),
+            settings=chromadb.Settings(
+                anonymized_telemetry=False,
+                allow_reset=False,
+            ),
+        )
+        logger.debug("Connected to ChromaDB")
+    except Exception as e:
+        logger.error(f"Failed to connect to ChromaDB: {e}")
+        return {"total": 0, "migrated": 0, "skipped": 0, "errors": 0}
+
+    # Get collection
+    try:
+        collection = client.get_collection(name=collection_name)
+        total_count = collection.count()
+        logger.info(f"Collection contains {total_count} chunks")
+    except Exception as e:
+        logger.error(f"Failed to get collection '{collection_name}': {e}")
+        return {"total": 0, "migrated": 0, "skipped": 0, "errors": 0}
+
+    if total_count == 0:
+        logger.warning("Collection is empty, nothing to migrate")
+        return {"total": 0, "migrated": 0, "skipped": 0, "errors": 0}
+
+    # Process chunks in batches
+    stats = {"total": total_count, "migrated": 0, "skipped": 0, "errors": 0}
+    offset = 0
+
+    while offset < total_count:
+        # Fetch batch
+        batch_limit = min(batch_size, total_count - offset)
+        logger.debug(f"Processing batch: {offset}-{offset + batch_limit}")
+
+        try:
+            results = collection.get(
+                include=["metadatas"],
+                limit=batch_limit,
+                offset=offset,
+            )
+
+            if not results or not results.get("ids"):
+                logger.warning(f"No results returned for offset {offset}")
+                break
+
+            # Check which chunks need migration
+            ids_to_update = []
+            metadatas_to_update = []
+
+            for chunk_id, metadata in zip(
+                results["ids"], results["metadatas"], strict=False
+            ):
+                # Check if chunk already has metrics
+                has_metrics = "cognitive_complexity" in metadata
+
+                if has_metrics:
+                    stats["skipped"] += 1
+                    logger.debug(f"Chunk {chunk_id} already has metrics, skipping")
+                    continue
+
+                # Need to add metrics
+                logger.debug(f"Chunk {chunk_id} needs metrics migration")
+
+                # Create updated metadata with defaults
+                updated_metadata = metadata.copy()
+                updated_metadata.update(DEFAULT_METRICS)
+
+                ids_to_update.append(chunk_id)
+                metadatas_to_update.append(updated_metadata)
+
+            # Update chunks (unless dry run)
+            if ids_to_update:
+                if dry_run:
+                    logger.info(
+                        f"[DRY RUN] Would update {len(ids_to_update)} chunks with default metrics"
+                    )
+                    stats["migrated"] += len(ids_to_update)
+                else:
+                    try:
+                        collection.update(
+                            ids=ids_to_update, metadatas=metadatas_to_update
+                        )
+                        stats["migrated"] += len(ids_to_update)
+                        logger.info(
+                            f"Migrated {len(ids_to_update)} chunks (total: {stats['migrated']}/{total_count})"
+                        )
+                    except Exception as e:
+                        logger.error(f"Failed to update batch: {e}")
+                        stats["errors"] += len(ids_to_update)
+
+            # Move to next batch
+            offset += batch_limit
+
+            # Yield to event loop
+            await asyncio.sleep(0)
+
+        except Exception as e:
+            logger.error(f"Error processing batch at offset {offset}: {e}")
+            stats["errors"] += batch_limit
+            offset += batch_limit
+
+    # Log final statistics
+    logger.info("Migration complete!")
+    logger.info(f"Total chunks: {stats['total']}")
+    logger.info(f"Migrated: {stats['migrated']}")
+    logger.info(f"Skipped (already had metrics): {stats['skipped']}")
+    logger.info(f"Errors: {stats['errors']}")
+
+    return stats
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Migrate ChromaDB chunks to include structural code metrics"
+    )
+    parser.add_argument(
+        "--persist-dir",
+        type=Path,
+        default=get_default_persist_dir(),
+        help="ChromaDB persist directory (default: .mcp-vector-search/chromadb)",
+    )
+    parser.add_argument(
+        "--collection",
+        type=str,
+        default="code_search",
+        help="Collection name (default: code_search)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without applying them",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of chunks to process per batch (default: 100)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    # Configure logging
+    logger.remove()  # Remove default handler
+    log_level = "DEBUG" if args.verbose else "INFO"
+    logger.add(
+        sys.stderr, level=log_level, format="<level>{level: <8}</level> | {message}"
+    )
+
+    # Run migration
+    try:
+        stats = asyncio.run(
+            migrate_metrics(
+                persist_dir=args.persist_dir,
+                collection_name=args.collection,
+                dry_run=args.dry_run,
+                batch_size=args.batch_size,
+            )
+        )
+
+        # Return exit code based on results
+        if stats["errors"] > 0:
+            logger.error(f"Migration completed with {stats['errors']} errors")
+            return 1
+        elif stats["total"] == 0:
+            logger.warning("No chunks found to migrate")
+            return 0
+        else:
+            logger.success("Migration completed successfully!")
+            return 0
+
+    except KeyboardInterrupt:
+        logger.warning("Migration interrupted by user")
+        return 130
+    except Exception as e:
+        logger.exception(f"Migration failed: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mcp_vector_search/analysis/metrics.py
+++ b/src/mcp_vector_search/analysis/metrics.py
@@ -67,12 +67,14 @@ class ChunkMetrics:
     def to_metadata(self) -> dict[str, Any]:
         """Flatten metrics for ChromaDB metadata storage.
 
-        ChromaDB supports: str, int, float, bool, list[str].
-        All metrics are flattened to these types.
+        ChromaDB supports: str, int, float, bool.
+        Lists are converted to JSON strings for compatibility.
 
         Returns:
             Dictionary of flattened metrics compatible with ChromaDB
         """
+        import json
+
         return {
             "cognitive_complexity": self.cognitive_complexity,
             "cyclomatic_complexity": self.cyclomatic_complexity,
@@ -80,7 +82,7 @@ class ChunkMetrics:
             "parameter_count": self.parameter_count,
             "lines_of_code": self.lines_of_code,
             "complexity_grade": self.complexity_grade,
-            "code_smells": self.smells,  # list[str] - compatible with ChromaDB
+            "code_smells": json.dumps(self.smells),  # Convert list to JSON string
             "smell_count": len(self.smells),
         }
 

--- a/tests/unit/analysis/test_metrics.py
+++ b/tests/unit/analysis/test_metrics.py
@@ -77,7 +77,7 @@ class TestChunkMetrics:
         assert metadata["parameter_count"] == 4
         assert metadata["lines_of_code"] == 50
         assert metadata["complexity_grade"] == "C"
-        assert metadata["code_smells"] == []
+        assert metadata["code_smells"] == "[]"  # JSON string for ChromaDB compatibility
         assert metadata["smell_count"] == 0
 
     def test_to_metadata_with_smells(self):
@@ -92,12 +92,15 @@ class TestChunkMetrics:
         # Verify all values are ChromaDB-compatible types
         assert isinstance(metadata["cognitive_complexity"], int)
         assert isinstance(metadata["complexity_grade"], str)
-        assert isinstance(metadata["code_smells"], list)
+        assert isinstance(metadata["code_smells"], str)  # JSON string for ChromaDB
         assert isinstance(metadata["smell_count"], int)
 
-        # Verify smell data
-        assert "long_method" in metadata["code_smells"]
-        assert "too_many_params" in metadata["code_smells"]
+        # Verify smell data (stored as JSON string)
+        import json
+
+        smells = json.loads(metadata["code_smells"])
+        assert "long_method" in smells
+        assert "too_many_params" in smells
         assert metadata["smell_count"] == 2
 
     def test_to_metadata_chromadb_compatibility(self):

--- a/tests/unit/core/test_database_metrics.py
+++ b/tests/unit/core/test_database_metrics.py
@@ -1,0 +1,547 @@
+"""Tests for ChromaDB metadata schema extensions for structural code metrics."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_vector_search.analysis.metrics import ChunkMetrics
+from mcp_vector_search.core.database import ChromaVectorDatabase
+from mcp_vector_search.core.models import CodeChunk
+
+
+@pytest.fixture
+def temp_db_dir(tmp_path: Path) -> Path:
+    """Create temporary database directory."""
+    db_dir = tmp_path / "test_chromadb"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return db_dir
+
+
+class MockEmbeddingFunction:
+    """Mock embedding function that implements ChromaDB's interface."""
+
+    def __call__(self, input: list[str]) -> list[list[float]]:
+        """Generate mock embeddings."""
+        return [[0.1, 0.2, 0.3]] * len(input)
+
+    def name(self) -> str:
+        """Return embedding function name."""
+        return "mock_embeddings"
+
+
+@pytest.fixture
+def mock_embedding_function() -> MockEmbeddingFunction:
+    """Create mock embedding function."""
+    return MockEmbeddingFunction()
+
+
+@pytest.fixture
+def sample_chunk() -> CodeChunk:
+    """Create sample code chunk."""
+    return CodeChunk(
+        content="def example():\n    return 42",
+        file_path=Path("test.py"),
+        start_line=1,
+        end_line=2,
+        language="python",
+        chunk_type="function",
+        function_name="example",
+        chunk_id="test_chunk_123",
+    )
+
+
+@pytest.fixture
+def sample_metrics() -> ChunkMetrics:
+    """Create sample metrics."""
+    return ChunkMetrics(
+        cognitive_complexity=5,
+        cyclomatic_complexity=2,
+        max_nesting_depth=1,
+        parameter_count=0,
+        lines_of_code=2,
+        smells=["too_short"],
+    )
+
+
+class TestDatabaseMetricsSupport:
+    """Test ChromaDB metadata schema extensions for metrics."""
+
+    @pytest.mark.asyncio
+    async def test_add_chunks_with_metrics(
+        self,
+        temp_db_dir: Path,
+        mock_embedding_function: MockEmbeddingFunction,
+        sample_chunk: CodeChunk,
+        sample_metrics: ChunkMetrics,
+    ) -> None:
+        """Test adding chunks with structural metrics."""
+        db = ChromaVectorDatabase(
+            persist_directory=temp_db_dir,
+            embedding_function=mock_embedding_function,
+        )
+
+        await db.initialize()
+
+        # Add chunk with metrics
+        metrics_dict = {sample_chunk.chunk_id: sample_metrics.to_metadata()}
+        await db.add_chunks([sample_chunk], metrics=metrics_dict)
+
+        # Retrieve and verify metrics were stored
+        chunks = await db.get_all_chunks()
+        assert len(chunks) == 1
+
+        # Verify metrics are in ChromaDB metadata (fetch directly from collection)
+        results = db._collection.get(ids=[sample_chunk.id], include=["metadatas"])
+        assert results["ids"]
+        metadata = results["metadatas"][0]
+
+        # Check all metrics fields
+        assert metadata["cognitive_complexity"] == 5
+        assert metadata["cyclomatic_complexity"] == 2
+        assert metadata["max_nesting_depth"] == 1
+        assert metadata["parameter_count"] == 0
+        assert metadata["lines_of_code"] == 2
+        assert metadata["complexity_grade"] == "A"  # Cognitive complexity 5 → Grade A
+        assert metadata["code_smells"] == '["too_short"]'  # JSON string
+        assert metadata["smell_count"] == 1
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_add_chunks_without_metrics(
+        self,
+        temp_db_dir: Path,
+        mock_embedding_function: MockEmbeddingFunction,
+        sample_chunk: CodeChunk,
+    ) -> None:
+        """Test backward compatibility: adding chunks without metrics."""
+        db = ChromaVectorDatabase(
+            persist_directory=temp_db_dir,
+            embedding_function=mock_embedding_function,
+        )
+
+        await db.initialize()
+
+        # Add chunk WITHOUT metrics (should work fine)
+        await db.add_chunks([sample_chunk])
+
+        # Retrieve chunk
+        chunks = await db.get_all_chunks()
+        assert len(chunks) == 1
+        assert chunks[0].content == sample_chunk.content
+
+        # Verify no metrics fields in metadata (they won't be present)
+        results = db._collection.get(ids=[sample_chunk.id], include=["metadatas"])
+        metadata = results["metadatas"][0]
+
+        # Metrics fields should not be present
+        assert "cognitive_complexity" not in metadata
+        assert "complexity_grade" not in metadata
+        assert "code_smells" not in metadata
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_search_filter_by_complexity_grade(
+        self,
+        temp_db_dir: Path,
+        mock_embedding_function: MockEmbeddingFunction,
+    ) -> None:
+        """Test filtering search results by complexity grade."""
+        db = ChromaVectorDatabase(
+            persist_directory=temp_db_dir,
+            embedding_function=mock_embedding_function,
+        )
+
+        await db.initialize()
+
+        # Create chunks with different complexity grades
+        chunks = [
+            CodeChunk(
+                content=f"def func_{i}():\n    return {i}",
+                file_path=Path(f"test_{i}.py"),
+                start_line=1,
+                end_line=2,
+                language="python",
+                chunk_type="function",
+                function_name=f"func_{i}",
+                chunk_id=f"chunk_{i}",
+            )
+            for i in range(3)
+        ]
+
+        # Create metrics with different grades
+        metrics_dict = {
+            "chunk_0": ChunkMetrics(cognitive_complexity=3).to_metadata(),  # Grade A
+            "chunk_1": ChunkMetrics(cognitive_complexity=8).to_metadata(),  # Grade B
+            "chunk_2": ChunkMetrics(cognitive_complexity=15).to_metadata(),  # Grade C
+        }
+
+        await db.add_chunks(chunks, metrics=metrics_dict)
+
+        # Search with complexity_grade filter for grade A
+        results = await db.search(
+            query="function",
+            limit=10,
+            filters={"complexity_grade": "A"},
+            similarity_threshold=0.0,
+        )
+
+        # Should only return grade A chunks
+        assert len(results) == 1
+
+        # Verify it's the grade A chunk by checking directly in ChromaDB
+        all_results = db._collection.get(
+            where={"complexity_grade": "A"}, include=["metadatas"]
+        )
+        assert len(all_results["ids"]) == 1
+        assert all_results["metadatas"][0]["complexity_grade"] == "A"
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_search_filter_by_smell_count(
+        self,
+        temp_db_dir: Path,
+        mock_embedding_function: MockEmbeddingFunction,
+    ) -> None:
+        """Test filtering by code smell count."""
+        db = ChromaVectorDatabase(
+            persist_directory=temp_db_dir,
+            embedding_function=mock_embedding_function,
+        )
+
+        await db.initialize()
+
+        # Create chunks with different smell counts
+        chunks = [
+            CodeChunk(
+                content=f"def func_{i}():\n    return {i}",
+                file_path=Path(f"test_{i}.py"),
+                start_line=1,
+                end_line=2,
+                language="python",
+                chunk_type="function",
+                function_name=f"func_{i}",
+                chunk_id=f"chunk_{i}",
+            )
+            for i in range(3)
+        ]
+
+        metrics_dict = {
+            "chunk_0": ChunkMetrics(smells=[]).to_metadata(),  # 0 smells
+            "chunk_1": ChunkMetrics(smells=["too_complex"]).to_metadata(),  # 1 smell
+            "chunk_2": ChunkMetrics(
+                smells=["too_complex", "too_long"]
+            ).to_metadata(),  # 2 smells
+        }
+
+        await db.add_chunks(chunks, metrics=metrics_dict)
+
+        # Search for chunks with NO smells (smell_count = 0)
+        results = await db.search(
+            query="function",
+            limit=10,
+            filters={"smell_count": 0},
+            similarity_threshold=0.0,
+        )
+
+        assert len(results) == 1
+
+        # Verify it's the clean chunk
+        clean_results = db._collection.get(
+            where={"smell_count": 0}, include=["metadatas"]
+        )
+        assert len(clean_results["ids"]) == 1
+        assert clean_results["metadatas"][0]["smell_count"] == 0
+
+        # Search for chunks with smells (smell_count > 0)
+        results = await db.search(
+            query="function",
+            limit=10,
+            filters={"smell_count": {"$gt": 0}},
+            similarity_threshold=0.0,
+        )
+
+        assert len(results) == 2  # Should return chunks with 1 and 2 smells
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_search_filter_by_complexity_range(
+        self,
+        temp_db_dir: Path,
+        mock_embedding_function: MockEmbeddingFunction,
+    ) -> None:
+        """Test range queries on cognitive complexity."""
+        db = ChromaVectorDatabase(
+            persist_directory=temp_db_dir,
+            embedding_function=mock_embedding_function,
+        )
+
+        await db.initialize()
+
+        # Create chunks with different complexities
+        chunks = [
+            CodeChunk(
+                content=f"def func_{i}():\n    return {i}",
+                file_path=Path(f"test_{i}.py"),
+                start_line=1,
+                end_line=2,
+                language="python",
+                chunk_type="function",
+                function_name=f"func_{i}",
+                chunk_id=f"chunk_{i}",
+            )
+            for i in range(4)
+        ]
+
+        metrics_dict = {
+            "chunk_0": ChunkMetrics(cognitive_complexity=5).to_metadata(),
+            "chunk_1": ChunkMetrics(cognitive_complexity=10).to_metadata(),
+            "chunk_2": ChunkMetrics(cognitive_complexity=15).to_metadata(),
+            "chunk_3": ChunkMetrics(cognitive_complexity=20).to_metadata(),
+        }
+
+        await db.add_chunks(chunks, metrics=metrics_dict)
+
+        # Search for moderate complexity (10-20 range)
+        # ChromaDB requires $and for range queries
+        results = await db.search(
+            query="function",
+            limit=10,
+            filters={
+                "$and": [
+                    {"cognitive_complexity": {"$gte": 10}},
+                    {"cognitive_complexity": {"$lte": 20}},
+                ]
+            },
+            similarity_threshold=0.0,
+        )
+
+        # Should return chunks with complexity 10, 15, 20
+        assert len(results) == 3
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_multiple_chunks_same_file(
+        self,
+        temp_db_dir: Path,
+        mock_embedding_function: MockEmbeddingFunction,
+    ) -> None:
+        """Test adding multiple chunks with different metrics from same file."""
+        db = ChromaVectorDatabase(
+            persist_directory=temp_db_dir,
+            embedding_function=mock_embedding_function,
+        )
+
+        await db.initialize()
+
+        # Create multiple chunks from same file
+        chunks = [
+            CodeChunk(
+                content="def func_a():\n    return 1",
+                file_path=Path("test.py"),
+                start_line=1,
+                end_line=2,
+                language="python",
+                chunk_type="function",
+                function_name="func_a",
+                chunk_id="chunk_a",
+            ),
+            CodeChunk(
+                content="def func_b():\n    return 2",
+                file_path=Path("test.py"),
+                start_line=4,
+                end_line=5,
+                language="python",
+                chunk_type="function",
+                function_name="func_b",
+                chunk_id="chunk_b",
+            ),
+        ]
+
+        # Different metrics for each chunk
+        metrics_dict = {
+            "chunk_a": ChunkMetrics(cognitive_complexity=3).to_metadata(),  # Grade A
+            "chunk_b": ChunkMetrics(cognitive_complexity=25).to_metadata(),  # Grade D
+        }
+
+        await db.add_chunks(chunks, metrics=metrics_dict)
+
+        # Verify both chunks stored with correct metrics
+        all_chunks = await db.get_all_chunks()
+        assert len(all_chunks) == 2
+
+        # Verify metrics in database
+        for chunk in chunks:
+            results = db._collection.get(ids=[chunk.id], include=["metadatas"])
+            metadata = results["metadatas"][0]
+            assert "cognitive_complexity" in metadata
+            assert "complexity_grade" in metadata
+
+        await db.close()
+
+
+class TestMigrationScript:
+    """Test migration script functionality (mock-based)."""
+
+    @pytest.mark.asyncio
+    async def test_migration_adds_default_metrics(self, tmp_path: Path) -> None:
+        """Test that migration adds default metrics to chunks without them."""
+        # Create temporary directory for test
+        test_dir = tmp_path / "chromadb"
+        test_dir.mkdir()
+
+        # Mock ChromaDB client and collection
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 2
+        mock_collection.get.return_value = {
+            "ids": ["chunk1", "chunk2"],
+            "metadatas": [
+                {"file_path": "test1.py", "language": "python"},  # No metrics
+                {
+                    "file_path": "test2.py",
+                    "language": "python",
+                    "cognitive_complexity": 5,
+                },  # Has metrics
+            ],
+        }
+        mock_collection.update = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = mock_collection
+
+        # Mock chromadb.PersistentClient
+        with patch("chromadb.PersistentClient", return_value=mock_client):
+            from scripts.migrate_chromadb_metrics import migrate_metrics
+
+            stats = await migrate_metrics(
+                persist_dir=test_dir, dry_run=False, batch_size=10
+            )
+
+            # Should migrate 1 chunk (chunk1), skip 1 chunk (chunk2)
+            assert stats["total"] == 2
+            assert stats["migrated"] == 1
+            assert stats["skipped"] == 1
+            assert stats["errors"] == 0
+
+            # Verify update was called with correct default metrics
+            mock_collection.update.assert_called_once()
+            call_args = mock_collection.update.call_args
+            assert call_args.kwargs["ids"] == ["chunk1"]
+
+            updated_metadata = call_args.kwargs["metadatas"][0]
+            assert updated_metadata["cognitive_complexity"] == 0
+            assert updated_metadata["cyclomatic_complexity"] == 1
+            assert updated_metadata["complexity_grade"] == "A"
+            assert updated_metadata["code_smells"] == "[]"  # JSON string
+            assert updated_metadata["smell_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_migration_dry_run(self, tmp_path: Path) -> None:
+        """Test migration in dry-run mode doesn't modify database."""
+        # Create temporary directory for test
+        test_dir = tmp_path / "chromadb"
+        test_dir.mkdir()
+
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 1
+        mock_collection.get.return_value = {
+            "ids": ["chunk1"],
+            "metadatas": [{"file_path": "test1.py"}],  # No metrics
+        }
+        mock_collection.update = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = mock_collection
+
+        with patch("chromadb.PersistentClient", return_value=mock_client):
+            from scripts.migrate_chromadb_metrics import migrate_metrics
+
+            stats = await migrate_metrics(
+                persist_dir=test_dir, dry_run=True, batch_size=10
+            )
+
+            # Should report migration but not actually update
+            assert stats["migrated"] == 1
+            mock_collection.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_migration_empty_collection(self) -> None:
+        """Test migration handles empty collection gracefully."""
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 0
+
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = mock_collection
+
+        with patch("chromadb.PersistentClient", return_value=mock_client):
+            from scripts.migrate_chromadb_metrics import migrate_metrics
+
+            stats = await migrate_metrics(
+                persist_dir=Path("/tmp/test"), dry_run=False, batch_size=10
+            )
+
+            assert stats["total"] == 0
+            assert stats["migrated"] == 0
+            assert stats["skipped"] == 0
+
+
+class TestMetricsIntegration:
+    """Integration tests for metrics with ChunkMetrics dataclass."""
+
+    def test_chunk_metrics_to_metadata_format(self) -> None:
+        """Test ChunkMetrics.to_metadata() produces ChromaDB-compatible format."""
+        metrics = ChunkMetrics(
+            cognitive_complexity=15,
+            cyclomatic_complexity=5,
+            max_nesting_depth=3,
+            parameter_count=4,
+            lines_of_code=50,
+            smells=["too_complex", "too_many_params"],
+        )
+
+        metadata = metrics.to_metadata()
+
+        # Verify all required fields
+        assert metadata["cognitive_complexity"] == 15
+        assert metadata["cyclomatic_complexity"] == 5
+        assert metadata["max_nesting_depth"] == 3
+        assert metadata["parameter_count"] == 4
+        assert metadata["lines_of_code"] == 50
+        assert metadata["complexity_grade"] == "C"  # 15 → grade C
+        assert metadata["smell_count"] == 2
+
+        # Verify types are ChromaDB-compatible
+        assert isinstance(metadata["cognitive_complexity"], int)
+        assert isinstance(metadata["complexity_grade"], str)
+        assert isinstance(metadata["code_smells"], str)  # JSON string now
+        # Verify we can parse it back to a list
+        import json
+
+        parsed_smells = json.loads(metadata["code_smells"])
+        assert parsed_smells == ["too_complex", "too_many_params"]
+
+    def test_complexity_grade_calculation(self) -> None:
+        """Test complexity grade is correctly calculated for different values."""
+        test_cases = [
+            (0, "A"),
+            (5, "A"),
+            (6, "B"),
+            (10, "B"),
+            (11, "C"),
+            (20, "C"),
+            (21, "D"),
+            (30, "D"),
+            (31, "F"),
+            (100, "F"),
+        ]
+
+        for complexity, expected_grade in test_cases:
+            metrics = ChunkMetrics(cognitive_complexity=complexity)
+            assert metrics.complexity_grade == expected_grade, (
+                f"Complexity {complexity} should be grade {expected_grade}"
+            )


### PR DESCRIPTION
## Summary

Extends the ChromaDB metadata schema to support structural code analysis metrics, enabling filtering by complexity grades and code smells.

### Changes

**src/mcp_vector_search/core/database.py**
- Added `metrics` parameter to `add_chunks()` method in `VectorDatabase` classes
- Enhanced `_build_where_clause()` to support filtering by:
  - `complexity_grade` (A/B/C/D/F)
  - `smell_count` (exact or range queries)
  - `cognitive_complexity` (range queries)

**src/mcp_vector_search/analysis/metrics.py**
- Updated `ChunkMetrics.to_metadata()` to serialize `code_smells` as JSON string (ChromaDB only supports str/int/float/bool in metadata)

**scripts/migrate_chromadb_metrics.py** (NEW)
- Idempotent migration script for existing indexes
- Adds default metric values to chunks without metrics
- Supports dry-run mode and batch processing
- CLI arguments for custom configurations

**tests/unit/core/test_database_metrics.py** (NEW)
- 11 comprehensive unit tests
- Tests for adding chunks with/without metrics (backward compatibility)
- Tests for filtering by complexity metrics

### Test Results

- ✅ 110 tests passing
- ✅ All pre-commit hooks pass
- ✅ mypy strict mode passes

## Test Plan

- [x] Unit tests for metrics support in database operations
- [x] Tests for backward compatibility (chunks without metrics)
- [x] Tests for complexity filtering queries
- [x] Migration script tests

Closes #9