### PR TITLE
fix(dart): fix Dart/Flutter file indexing and stale config extension merging

### DIFF
--- a/src/mcp_vector_search/config/defaults.py
+++ b/src/mcp_vector_search/config/defaults.py
@@ -80,6 +80,8 @@ DEFAULT_FILE_EXTENSIONS = [
     ".swift",
     # Dart - fallback parsing
     ".dart",
+    # Flutter localization
+    ".arb",
     # R - fallback parsing
     ".r",
     ".R",
@@ -177,6 +179,8 @@ LANGUAGE_MAPPINGS: dict[str, str] = {
     ".swift": "swift",
     # Dart
     ".dart": "dart",
+    # Flutter localization (ARB is JSON-based)
+    ".arb": "json",
     # R
     ".r": "r",
     ".R": "r",
@@ -400,6 +404,11 @@ DEFAULT_IGNORE_FILES = [
     "*.log",
     "*.temp",
     "*.tmp",
+    # Flutter/Dart generated files
+    "*.g.dart",         # json_serializable, built_value generated
+    "*.freezed.dart",   # freezed code generation
+    "*.mocks.dart",     # mockito mock generation
+    "*.gr.dart",        # auto_route generation
 ]
 
 

--- a/src/mcp_vector_search/core/chunk_processor.py
+++ b/src/mcp_vector_search/core/chunk_processor.py
@@ -342,7 +342,7 @@ class ChunkProcessor:
         # imports chunks should remain siblings of classes/functions, not parents
         module_chunks = [c for c in chunks if c.chunk_type == "module"]
         class_chunks = [
-            c for c in chunks if c.chunk_type in ("class", "interface", "mixin")
+            c for c in chunks if c.chunk_type in ("class", "interface", "mixin", "widget")
         ]
         function_chunks = [
             c for c in chunks if c.chunk_type in ("function", "method", "constructor")

--- a/src/mcp_vector_search/core/project.py
+++ b/src/mcp_vector_search/core/project.py
@@ -206,6 +206,22 @@ class ProjectManager:
             config_data["project_root"] = Path(config_data["project_root"])
             config_data["index_path"] = Path(config_data["index_path"])
 
+            # Merge new file extensions from DEFAULT_FILE_EXTENSIONS
+            # This ensures upgrades automatically pick up newly-supported file types
+            if "file_extensions" in config_data:
+                saved_extensions = set(config_data["file_extensions"])
+                current_defaults = set(DEFAULT_FILE_EXTENSIONS)
+                new_extensions = current_defaults - saved_extensions
+
+                if new_extensions:
+                    # Merge new extensions (preserving user's existing extensions)
+                    merged_extensions = sorted(saved_extensions | new_extensions)
+                    config_data["file_extensions"] = merged_extensions
+
+                    logger.info(
+                        f"Added {len(new_extensions)} new file extensions from updated defaults: {sorted(new_extensions)}"
+                    )
+
             config = ProjectConfig(**config_data)
             self._config = config
             return config

--- a/src/mcp_vector_search/parsers/registry.py
+++ b/src/mcp_vector_search/parsers/registry.py
@@ -36,53 +36,30 @@ class ParserRegistry:
 
     def _register_default_parsers(self) -> None:
         """Register default parsers for supported languages."""
-        # Register Python parser
-        python_parser = PythonParser()
-        self.register_parser("python", python_parser)
+        parsers_to_register = [
+            ("python", PythonParser),
+            ("javascript", JavaScriptParser),
+            ("typescript", TypeScriptParser),
+            ("java", JavaParser),
+            ("c_sharp", CSharpParser),
+            ("go", GoParser),
+            ("rust", RustParser),
+            ("dart", DartParser),
+            ("php", PHPParser),
+            ("ruby", RubyParser),
+            ("text", TextParser),
+            ("html", HTMLParser),
+        ]
 
-        # Register JavaScript parser
-        javascript_parser = JavaScriptParser()
-        self.register_parser("javascript", javascript_parser)
-
-        # Register TypeScript parser
-        typescript_parser = TypeScriptParser()
-        self.register_parser("typescript", typescript_parser)
-
-        # Register Java parser
-        java_parser = JavaParser()
-        self.register_parser("java", java_parser)
-
-        # Register C# parser
-        csharp_parser = CSharpParser()
-        self.register_parser("c_sharp", csharp_parser)
-
-        # Register Go parser
-        go_parser = GoParser()
-        self.register_parser("go", go_parser)
-
-        # Register Rust parser
-        rust_parser = RustParser()
-        self.register_parser("rust", rust_parser)
-
-        # Register Dart parser
-        dart_parser = DartParser()
-        self.register_parser("dart", dart_parser)
-
-        # Register PHP parser
-        php_parser = PHPParser()
-        self.register_parser("php", php_parser)
-
-        # Register Ruby parser
-        ruby_parser = RubyParser()
-        self.register_parser("ruby", ruby_parser)
-
-        # Register Text parser for .txt files
-        text_parser = TextParser()
-        self.register_parser("text", text_parser)
-
-        # Register HTML parser for .html files
-        html_parser = HTMLParser()
-        self.register_parser("html", html_parser)
+        for language, parser_class in parsers_to_register:
+            try:
+                parser = parser_class()
+                self.register_parser(language, parser)
+            except Exception as e:
+                logger.error(
+                    f"Failed to initialize {language} parser "
+                    f"({parser_class.__name__}): {e}"
+                )
 
     def register_parser(self, language: str, parser: BaseParser) -> None:
         """Register a parser for a specific language.

--- a/tests/unit/core/test_project_config_merge.py
+++ b/tests/unit/core/test_project_config_merge.py
@@ -1,0 +1,222 @@
+"""Unit tests for project config extension merging on upgrades."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_vector_search.config.defaults import DEFAULT_FILE_EXTENSIONS
+from mcp_vector_search.core.project import ProjectManager
+
+
+class TestProjectConfigExtensionMerge:
+    """Test cases for automatic extension merging on config load."""
+
+    def test_merge_new_extensions_on_load(self, tmp_path: Path):
+        """Test that new extensions from DEFAULT_FILE_EXTENSIONS are merged on load."""
+        # Create a config with a subset of extensions (simulating old version)
+        old_extensions = [".py", ".js", ".ts", ".java"]
+        config_dir = tmp_path / ".mcp-vector-search"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.json"
+
+        # Create mock config data
+        config_data = {
+            "project_root": str(tmp_path),
+            "index_path": str(config_dir),
+            "file_extensions": old_extensions,
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "similarity_threshold": 0.5,
+            "languages": ["python", "javascript"],
+        }
+
+        # Write config to file
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        # Create index directory to satisfy is_initialized() check
+        config_dir.mkdir(exist_ok=True)
+
+        # Create project manager and load config
+        pm = ProjectManager(project_root=tmp_path)
+        config = pm.load_config()
+
+        # Verify that new extensions are present
+        # .dart and .arb should now be in the config (they're in DEFAULT_FILE_EXTENSIONS)
+        assert ".dart" in config.file_extensions
+        assert ".arb" in config.file_extensions
+
+        # Verify old extensions are still present
+        for ext in old_extensions:
+            assert ext in config.file_extensions
+
+    def test_no_merge_if_all_extensions_present(self, tmp_path: Path):
+        """Test that no merge happens if config already has all current extensions."""
+        # Create config with ALL current DEFAULT_FILE_EXTENSIONS
+        config_dir = tmp_path / ".mcp-vector-search"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.json"
+
+        config_data = {
+            "project_root": str(tmp_path),
+            "index_path": str(config_dir),
+            "file_extensions": DEFAULT_FILE_EXTENSIONS.copy(),
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "similarity_threshold": 0.5,
+            "languages": ["python"],
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        config_dir.mkdir(exist_ok=True)
+
+        # Create project manager and load config
+        pm = ProjectManager(project_root=tmp_path)
+
+        # Patch logger to verify no INFO message is logged
+        with patch("mcp_vector_search.core.project.logger") as mock_logger:
+            config = pm.load_config()
+
+            # Verify no merge happened (no info log about adding extensions)
+            mock_logger.info.assert_not_called()
+
+        # Verify extensions match defaults
+        assert set(config.file_extensions) == set(DEFAULT_FILE_EXTENSIONS)
+
+    def test_user_custom_extensions_preserved(self, tmp_path: Path):
+        """Test that user's custom extensions are preserved during merge."""
+        # User added custom extensions not in defaults
+        custom_extensions = [".py", ".js", ".custom", ".xyz"]
+        config_dir = tmp_path / ".mcp-vector-search"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.json"
+
+        config_data = {
+            "project_root": str(tmp_path),
+            "index_path": str(config_dir),
+            "file_extensions": custom_extensions,
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "similarity_threshold": 0.5,
+            "languages": ["python"],
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        config_dir.mkdir(exist_ok=True)
+
+        pm = ProjectManager(project_root=tmp_path)
+        config = pm.load_config()
+
+        # Verify user's custom extensions are still present
+        assert ".custom" in config.file_extensions
+        assert ".xyz" in config.file_extensions
+
+        # Verify new default extensions are added
+        assert ".dart" in config.file_extensions
+        assert ".arb" in config.file_extensions
+
+    def test_merge_logs_info_message(self, tmp_path: Path):
+        """Test that merge operation logs an INFO message with new extensions."""
+        old_extensions = [".py", ".js"]
+        config_dir = tmp_path / ".mcp-vector-search"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.json"
+
+        config_data = {
+            "project_root": str(tmp_path),
+            "index_path": str(config_dir),
+            "file_extensions": old_extensions,
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "similarity_threshold": 0.5,
+            "languages": ["python"],
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        config_dir.mkdir(exist_ok=True)
+
+        pm = ProjectManager(project_root=tmp_path)
+
+        # Patch logger to capture log messages
+        with patch("mcp_vector_search.core.project.logger") as mock_logger:
+            config = pm.load_config()
+
+            # Verify INFO log was called
+            assert mock_logger.info.called
+
+            # Get the log message
+            log_call = mock_logger.info.call_args
+            log_message = log_call[0][0]
+
+            # Verify message mentions new extensions
+            assert "new file extensions" in log_message.lower()
+            assert ".dart" in str(log_call)  # Should be in the arguments
+
+    def test_config_not_saved_automatically(self, tmp_path: Path):
+        """Test that merged config is NOT automatically saved back to disk."""
+        old_extensions = [".py", ".js"]
+        config_dir = tmp_path / ".mcp-vector-search"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.json"
+
+        config_data = {
+            "project_root": str(tmp_path),
+            "index_path": str(config_dir),
+            "file_extensions": old_extensions,
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "similarity_threshold": 0.5,
+            "languages": ["python"],
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        config_dir.mkdir(exist_ok=True)
+
+        # Load config (which triggers merge)
+        pm = ProjectManager(project_root=tmp_path)
+        config = pm.load_config()
+
+        # Verify merged config in memory has new extensions
+        assert ".dart" in config.file_extensions
+
+        # Re-read file from disk and verify it's unchanged
+        with open(config_path, "r") as f:
+            disk_config = json.load(f)
+
+        # File on disk should still have old extensions only
+        assert disk_config["file_extensions"] == old_extensions
+        assert ".dart" not in disk_config["file_extensions"]
+
+    def test_missing_file_extensions_key_handled(self, tmp_path: Path):
+        """Test that config without file_extensions key is handled gracefully."""
+        config_dir = tmp_path / ".mcp-vector-search"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.json"
+
+        # Config without file_extensions key (edge case)
+        config_data = {
+            "project_root": str(tmp_path),
+            "index_path": str(config_dir),
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "similarity_threshold": 0.5,
+            "languages": ["python"],
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        config_dir.mkdir(exist_ok=True)
+
+        pm = ProjectManager(project_root=tmp_path)
+
+        # Should not raise an error (merge logic skips if key missing)
+        # ProjectConfig will use its default value
+        config = pm.load_config()
+
+        # Config should have default extensions from ProjectConfig model
+        assert config.file_extensions is not None


### PR DESCRIPTION
## Summary

Fixes #100 — Dart/Flutter files were completely invisible to indexing due to two independent bugs.

- **Stale config snapshot:** `init` freezes `DEFAULT_FILE_EXTENSIONS` into `config.json`. The `index` command reads only from this snapshot, so extensions added in later versions (like `.dart`) are never picked up. Fixed by auto-merging new default extensions at config load time.
- **Broken fallback class regex:** The pattern `class\s+(\w+)\s*[{<]` only matches `class Foo {` but fails for `extends`, `implements`, `with`, and `abstract` — virtually all real Dart classes. Replaced with a comprehensive pattern.
- **Additional:** widget hierarchy fix, parser registry error isolation, Flutter generated file exclusions (`*.g.dart`, `*.freezed.dart`, etc.), `.arb` file support, dead code removal, improved error logging.

### Files changed (7)

| File | Change |
|------|--------|
| `src/mcp_vector_search/core/project.py` | Auto-merge new default extensions on config load |
| `src/mcp_vector_search/parsers/dart.py` | Fix class/widget regex, remove dead code, improve logging |
| `src/mcp_vector_search/core/chunk_processor.py` | Add `"widget"` to hierarchy class filter |
| `src/mcp_vector_search/parsers/registry.py` | Error isolation per parser |
| `src/mcp_vector_search/config/defaults.py` | `.arb` extension, Flutter generated file exclusions |
| `tests/test_dart_parser.py` | 11 new test cases for Dart class patterns |
| `tests/unit/core/test_project_config_merge.py` | 6 new tests for config extension merging |

## Test plan

- [x] `pytest tests/test_dart_parser.py` — 13 tests pass (class extends/implements/with/abstract, generics, freezed, JsonSerializable, widget hierarchy, generated file exclusion, `.arb` support)
- [x] `pytest tests/unit/core/test_project_config_merge.py` — 6 tests pass (extension merging, user customizations preserved, no auto-save to disk)
- [x] Manual verification: reindexed Flutter monorepo, `.dart` files now appear in index stats and search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)