### PR TITLE
feat(indexer): configurable index_path + idempotent table creation

### DIFF
--- a/src/mcp_vector_search/core/factory.py
+++ b/src/mcp_vector_search/core/factory.py
@@ -87,13 +87,25 @@ class ComponentFactory:
 
     @staticmethod
     def create_indexer(
-        database: VectorDatabase, project_root: Path, config: ProjectConfig
+        database: VectorDatabase,
+        project_root: Path,
+        config: ProjectConfig,
+        index_path: str | None = None,
     ) -> SemanticIndexer:
-        """Create semantic indexer."""
+        """Create semantic indexer.
+
+        Args:
+            database: Vector database instance
+            project_root: Project root directory (where source code lives)
+            config: Project configuration
+            index_path: Optional separate directory for .mcp-vector-search/ index data.
+                Falls back to INDEX_PATH env var, then project_root.
+        """
         return SemanticIndexer(
             database=database,
             project_root=project_root,
             config=config,
+            index_path=index_path,
         )
 
     @staticmethod

--- a/src/mcp_vector_search/migrations/v2_3_0_two_phase.py
+++ b/src/mcp_vector_search/migrations/v2_3_0_two_phase.py
@@ -254,7 +254,7 @@ class TwoPhaseArchitectureMigration(Migration):
                 # Let LanceDB infer schema from data (handles extra columns gracefully)
                 # Using explicit schema would fail on forward-compatible migrations
                 # when new columns are added to the schema definition
-                db.create_table(self.NEW_CHUNKS_TABLE, chunks_data)
+                db.create_table(self.NEW_CHUNKS_TABLE, chunks_data, mode="overwrite")
                 logger.info(f"✓ Created chunks table with {len(chunks_data):,} rows")
                 metadata["chunks_migrated"] = len(chunks_data)
 
@@ -265,7 +265,7 @@ class TwoPhaseArchitectureMigration(Migration):
                 # 1. Vector dimension varies (384 for MiniLM, 768 for GraphCodeBERT, etc.)
                 # 2. Schema has evolved over time (function_name, class_name, project_name added)
                 # 3. Migration must be forward-compatible with schema changes
-                db.create_table(self.NEW_VECTORS_TABLE, vectors_data)
+                db.create_table(self.NEW_VECTORS_TABLE, vectors_data, mode="overwrite")
                 logger.info(f"✓ Created vectors table with {len(vectors_data):,} rows")
                 metadata["vectors_migrated"] = len(vectors_data)
 


### PR DESCRIPTION
## Summary
Two P0 fixes in one branch:

### 1. Configurable `index_path` for SemanticIndexer (#111)
- Adds `index_path: str | None = None` parameter to `SemanticIndexer.__init__()`
- Resolution order: explicit parameter > `INDEX_PATH` env var > `project_root` (backward compatible)
- Replaces **10 hardcoded** `project_root / ".mcp-vector-search"` references with `self.index_path`
- Enables production setups where index storage differs from source code location

### 2. Idempotent LanceDB table creation (#112)
- All `create_table()` calls now use `exist_ok=True` or `mode="overwrite"`
- Eliminates "Table already exists" errors during re-indexing
- Net **-80 lines** by replacing ~10 fragile check-then-create blocks with idempotent calls
- Migration tables use `mode="overwrite"` so interrupted migrations can be re-run safely

## Impact
- **#111**: Eliminates production incidents where indexer writes to wrong path in dual-instance setups
- **#112**: Eliminates need for manual `reset_index()` before re-indexing (DCI finding #14)

Closes #111
Closes #112

## Test plan
- [ ] All 20 existing unit tests pass
- [ ] Pre-commit hooks pass (ruff, mypy, bandit)  
- [ ] `index_path=None` preserves existing behavior (backward compatible)
- [ ] `INDEX_PATH` env var is respected as fallback
- [ ] Re-indexing without reset no longer throws "Table already exists"

🤖 Generated with [Claude Code](https://claude.com/claude-code)