### PR TITLE
chore: bump version to 4.0.0 — Privacy Policy Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,46 @@ Automatically reads and applies standards from your existing config files:
 
 ---
 
+## Privacy Policy Auditor
+
+Audit codebases against their stated privacy policies using semantic code search and knowledge graph analysis.
+
+### Quick Start
+```bash
+# Install with auditor dependencies
+pip install 'mcp-vector-search[auditor]'
+
+# Run a privacy audit
+mvs audit run --target /path/to/repo --policy /path/to/repo/PRIVACY.md
+
+# Check for policy/code drift
+mvs audit drift-check --target /path/to/repo --policy /path/to/repo/PRIVACY.md
+
+# Verify a certification
+mvs audit verify audits/<target>/latest/
+
+# List audit history
+mvs audit list
+```
+
+### How It Works
+1. **Extract Claims** — Parses privacy policies into testable assertions (hybrid text analysis + LLM)
+2. **Collect Evidence** — Queries the codebase via vector search, hybrid search, and knowledge graph
+3. **Judge Verdicts** — LLM evaluates each claim against evidence (PASS / FAIL / INSUFFICIENT / MANUAL_REVIEW)
+4. **Certify** — Produces signed certification documents with per-claim verdicts and evidence
+
+### Features
+- **Dual output** — Certification saved in both auditor repo and target repo
+- **Multiple LLM backends** — OpenRouter and Anthropic (auto-detected)
+- **GitHub Actions** — On-demand audit workflow + daily drift detection
+- **GPG signing** — Optional cryptographic signatures for certification integrity
+- **Auto-issue creation** — GitHub issues for claims needing review
+- **.audit-ignore.yml** — Suppress specific claims with documented justifications
+
+See [docs/features/privacy-auditor.md](docs/features/privacy-auditor.md) for full documentation.
+
+---
+
 ## 📖 Documentation
 
 ### Commands

--- a/src/mcp_vector_search/__init__.py
+++ b/src/mcp_vector_search/__init__.py
@@ -7,8 +7,8 @@ import warnings
 # with Pydantic's protected "model_" namespace. This is a lancedb issue, not ours.
 warnings.filterwarnings("ignore", message=".*has conflict with protected namespace.*")
 
-__version__ = "3.0.76"
-__build__ = "301"
+__version__ = "4.0.0"
+__build__ = "400"
 __author__ = "Robert Matsuoka"
 __email__ = "bob@matsuoka.com"
 


### PR DESCRIPTION
## Summary

- Bumps version from 3.0.76 to 4.0.0 (major version — new Privacy Policy Auditor feature)
- Adds Privacy Policy Auditor section to README.md

## What's New

Major new feature: **Privacy Policy Auditor** — a complete privacy-policy-vs-code certification tool.

- 12 new modules under `src/mcp_vector_search/auditor/`
- CLI: `mvs audit run/verify/list/drift-check`
- GitHub Actions: on-demand audit + daily drift detection
- Dual output (target repo + auditor repo)
- OpenRouter + Anthropic LLM backends (auto-detected)
- GPG-signed certification documents
- Auto-creates GitHub issues for claims requiring manual review
- 242 unit tests

## Test plan
- [ ] Verify `mvs --version` shows `4.0.0`
- [ ] Confirm README Privacy Policy Auditor section renders correctly on GitHub
- [ ] Confirm `pip install 'mcp-vector-search[auditor]'` installs auditor extras

🤖 Generated with [Claude Code](https://claude.com/claude-code)