### PR TITLE
Update dependency references from chromadb to lancedb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,12 @@ submodule-status: ## Show git submodule status
 	@echo "$(BLUE)Git Submodule Status:$(NC)"
 	@git submodule status
 
+.PHONY: dev
+dev: submodule-sync ## Sync submodules and install dependencies
+	@echo "$(GREEN)Syncing dependencies...$(NC)"
+	$(UV) sync
+	@echo "$(GREEN)✓ Development environment ready$(NC)"
+
 .PHONY: clean-submodules
 clean-submodules: ## Clean submodule build artifacts
 	@echo "$(GREEN)Cleaning submodule artifacts...$(NC)"

--- a/README.md
+++ b/README.md
@@ -989,8 +989,8 @@ cd mcp-vector-search
 make dev
 
 # Test CLI from source (recommended during development)
-./dev-mcp version        # Shows [DEV] indicator
-./dev-mcp search "test"  # No reinstall needed after code changes
+./scripts/dev-mcp version        # Shows [DEV] indicator
+./scripts/dev-mcp search "test"  # No reinstall needed after code changes
 
 # Run tests and quality checks
 make test-unit           # Run unit tests

--- a/src/mcp_vector_search/cli/commands/status.py
+++ b/src/mcp_vector_search/cli/commands/status.py
@@ -970,7 +970,7 @@ def check_dependencies() -> bool:
         bool: True if all dependencies are available, False otherwise.
     """
     dependencies = [
-        ("chromadb", "ChromaDB"),
+        ("lancedb", "LanceDB"),
         ("sentence_transformers", "Sentence Transformers"),
         ("tree_sitter", "Tree-sitter"),
         ("tree_sitter_language_pack", "Tree-sitter Languages"),


### PR DESCRIPTION
# PR Title: Update dependency references from chromadb to lancedb

## Motivation

This project completed its migration from chromadb to lancedb, but several references to the old dependency remained in the codebase. The dependency check tool and development documentation were not updated to reflect this change. This PR finalizes the migration by removing all chromadb references and fixing related tooling paths.

## Problems Solved

- Dependency status check incorrectly reported chromadb as required instead of lancedb
- Development documentation referenced outdated script paths
- Development setup target missing from Makefile

## Summary of Changes

| File | Change | Reason |
|------|--------|--------|
| `src/mcp_vector_search/cli/commands/status.py` | Replace chromadb with lancedb in expected dependencies list | Reflect actual migration to lancedb |
| `Makefile` | Add `.PHONY: dev` and new `dev` target for syncing dependencies | Provide convenient development environment setup |
| `README.md` | Update dev-mcp script paths to use `./scripts/` directory | Correct documentation to match actual script location |

## Reviewer Notes

- The chromadb → lancedb swap in `status.py` is straightforward and aligns with the existing project migration
- The new `dev` target in Makefile follows the established pattern and includes appropriate messaging
- README updates are documentation-only and contain no functional changes
- No breaking changes; all modifications are cleanup and corrections