### PR TITLE
Avoid importing POSIX resource module on Windows

### DIFF
--- a/src/mcp_vector_search/cli/main.py
+++ b/src/mcp_vector_search/cli/main.py
@@ -1,7 +1,6 @@
 """Main CLI application for MCP Vector Search."""
 
 import faulthandler
-import resource
 import signal
 import sys
 from pathlib import Path
@@ -36,6 +35,8 @@ def _raise_file_descriptor_limit() -> None:
         return
 
     try:
+        import resource
+
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         # Try to set to 65535 (or hard limit if lower)
         new_limit = min(65535, hard)

--- a/tests/unit/cli/test_signal_handlers.py
+++ b/tests/unit/cli/test_signal_handlers.py
@@ -1,11 +1,25 @@
 """Tests for CLI signal handlers."""
 
+import ast
 import signal
 import sys
 from io import StringIO
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+
+def test_resource_module_is_not_imported_at_module_load():
+    """Ensure Windows can import the CLI without the POSIX-only resource module."""
+    source = Path("src/mcp_vector_search/cli/main.py").read_text()
+    module = ast.parse(source)
+
+    for node in module.body:
+        if isinstance(node, ast.Import):
+            assert all(alias.name != "resource" for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module != "resource"
 
 
 def test_segfault_handler_registered():


### PR DESCRIPTION
## Summary
- move the POSIX-only `resource` import inside `_raise_file_descriptor_limit()` after the Windows guard
- add a regression test that prevents reintroducing a top-level `resource` import in the CLI entry module

Fixes #178.

## Validation
- `uv run --python 3.11 pytest tests/unit/cli/test_signal_handlers.py` (5 passed)
- `uvx ruff check src/mcp_vector_search/cli/main.py tests/unit/cli/test_signal_handlers.py`
- `uvx ruff format --check src/mcp_vector_search/cli/main.py tests/unit/cli/test_signal_handlers.py`
- `python3 -m py_compile src/mcp_vector_search/cli/main.py tests/unit/cli/test_signal_handlers.py`
- `git diff --check`

I first tried plain `uv run pytest ...`, but `uv` selected Python 3.14 and attempted to build `kuzu==0.11.3` from source, which failed because `cmake` is not installed locally. Re-running with Python 3.11 used available wheels and passed.

Disclosure: this PR was prepared by an AI coding agent as a public help-first contribution.