### PR TITLE
Fix MCP success exit code

### DIFF
--- a/src/mcp_vector_search/cli/commands/mcp.py
+++ b/src/mcp_vector_search/cli/commands/mcp.py
@@ -71,15 +71,16 @@ def mcp_callback(ctx: typer.Context):
     if project_root is None:
         project_root = Path.cwd()
 
-    # Start the MCP server over stdio
+    # Start the MCP server over stdio. Keep the success exit outside the
+    # catch-all so typer.Exit(0) is not mistaken for a server failure.
     try:
         asyncio.run(run_mcp_server(project_root))
-        raise typer.Exit(0)
     except KeyboardInterrupt:
         raise typer.Exit(0)
     except Exception as e:
         print(f"MCP server error: {e}", file=sys.stderr)
         raise typer.Exit(1)
+    raise typer.Exit(0)
 
 
 # Supported AI tools and their configuration details

--- a/tests/unit/cli/test_mcp_callback.py
+++ b/tests/unit/cli/test_mcp_callback.py
@@ -1,0 +1,50 @@
+"""Tests for the MCP CLI callback."""
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from mcp_vector_search.cli.commands.mcp import mcp_callback
+
+
+def install_stub_mcp_server(monkeypatch):
+    """Install a lightweight MCP server module for callback control-flow tests."""
+    package = types.ModuleType("mcp_vector_search.mcp")
+    server = types.ModuleType("mcp_vector_search.mcp.server")
+
+    def run_mcp_server(project_root):  # pragma: no cover - asyncio.run is mocked
+        return None
+
+    server.run_mcp_server = run_mcp_server
+    monkeypatch.setitem(sys.modules, "mcp_vector_search.mcp", package)
+    monkeypatch.setitem(sys.modules, "mcp_vector_search.mcp.server", server)
+
+
+def test_mcp_callback_success_exits_zero(monkeypatch):
+    """A clean MCP server shutdown should not be caught as a failure."""
+    install_stub_mcp_server(monkeypatch)
+    ctx = SimpleNamespace(obj={"project_root": Path.cwd()}, invoked_subcommand=None)
+
+    with patch("asyncio.run", return_value=None):
+        with pytest.raises(typer.Exit) as exc_info:
+            mcp_callback(ctx)
+
+    assert exc_info.value.exit_code == 0
+
+
+def test_mcp_callback_server_error_exits_one(monkeypatch, capsys):
+    """Unexpected MCP server errors should still be surfaced as failures."""
+    install_stub_mcp_server(monkeypatch)
+    ctx = SimpleNamespace(obj={"project_root": Path.cwd()}, invoked_subcommand=None)
+
+    with patch("asyncio.run", side_effect=RuntimeError("boom")):
+        with pytest.raises(typer.Exit) as exc_info:
+            mcp_callback(ctx)
+
+    assert exc_info.value.exit_code == 1
+    assert "MCP server error: boom" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- move the MCP callback success `typer.Exit(0)` outside the broad `try`/`except Exception` block
- keep `KeyboardInterrupt` as a clean exit
- add focused regression coverage for clean MCP shutdown and unexpected server failure

## Why

The previous success path raised `typer.Exit(0)` inside a `try` block guarded by `except Exception`. Since `typer.Exit` is an exception type, a clean MCP server shutdown can be converted into the `"MCP server error: 0"` / exit-code-1 failure path reported in #174.

## Validation

```bash
python3 -m py_compile src/mcp_vector_search/cli/commands/mcp.py tests/unit/cli/test_mcp_callback.py
PYTHONPATH=src .venv/bin/python -m pytest -o addopts= --confcutdir=tests/unit/cli tests/unit/cli/test_mcp_callback.py -q
.venv/bin/python -m ruff check src/mcp_vector_search/cli/commands/mcp.py tests/unit/cli/test_mcp_callback.py
```

Result:

```text
2 passed
All checks passed
```

Fixes #174
